### PR TITLE
PoC for multitenancy support

### DIFF
--- a/event_sourcery/event_store/context.py
+++ b/event_sourcery/event_store/context.py
@@ -1,0 +1,33 @@
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Iterator
+
+
+@dataclass
+class Context:
+    tenant_id: int | None
+
+
+_event_store_context: ContextVar[Context] = ContextVar(
+    "event_sourcery_event_store_context"
+)
+
+
+@contextmanager
+def event_sourcery_context(tenant_id: int) -> Iterator[None]:
+    """Could be used with many different event store instances.
+
+    Also, in e.g. middleware. Not necessarily in the place when EventStore is used.
+    """
+    new_context = Context(tenant_id=tenant_id)
+    token = _event_store_context.set(new_context)
+    yield
+    _event_store_context.reset(token)
+
+
+def get_context() -> Context:
+    try:
+        return _event_store_context.get()
+    except LookupError:
+        return Context(tenant_id=None)

--- a/event_sourcery/event_store/in_memory.py
+++ b/event_sourcery/event_store/in_memory.py
@@ -16,6 +16,7 @@ from event_sourcery.event_store import (
     EventStore,
     subscription,
 )
+from event_sourcery.event_store.context import Context
 from event_sourcery.event_store.event import Position, RawEvent, RecordedRaw, Serde
 from event_sourcery.event_store.exceptions import ConcurrentStreamWriteError
 from event_sourcery.event_store.factory import (
@@ -230,6 +231,7 @@ class InMemoryStorageStrategy(StorageStrategy):
     def fetch_events(
         self,
         stream_id: StreamId,
+        context: Context,
         start: int | None = None,
         stop: int | None = None,
     ) -> list[RawEvent]:
@@ -242,7 +244,11 @@ class InMemoryStorageStrategy(StorageStrategy):
         return list(stream)
 
     def insert_events(
-        self, stream_id: StreamId, versioning: Versioning, events: list[RawEvent]
+        self,
+        stream_id: StreamId,
+        versioning: Versioning,
+        events: list[RawEvent],
+        context: Context,
     ) -> None:
         self._ensure_stream(stream_id=stream_id, versioning=versioning)
         self._storage.append(events)

--- a/event_sourcery/event_store/interfaces.py
+++ b/event_sourcery/event_store/interfaces.py
@@ -2,6 +2,7 @@ import abc
 from datetime import timedelta
 from typing import ContextManager, Iterator, Protocol
 
+from event_sourcery.event_store.context import Context
 from event_sourcery.event_store.event import Position, RawEvent, RecordedRaw
 from event_sourcery.event_store.stream_id import StreamId
 from event_sourcery.event_store.versioning import Versioning
@@ -54,6 +55,7 @@ class StorageStrategy(abc.ABC):
     def fetch_events(
         self,
         stream_id: StreamId,
+        context: Context,
         start: int | None = None,
         stop: int | None = None,
     ) -> list[RawEvent]:
@@ -61,7 +63,11 @@ class StorageStrategy(abc.ABC):
 
     @abc.abstractmethod
     def insert_events(
-        self, stream_id: StreamId, versioning: Versioning, events: list[RawEvent]
+        self,
+        stream_id: StreamId,
+        versioning: Versioning,
+        events: list[RawEvent],
+        context: Context,
     ) -> None:
         pass
 

--- a/event_sourcery_django/migrations/0001_initial.py
+++ b/event_sourcery_django/migrations/0001_initial.py
@@ -33,6 +33,7 @@ class Migration(migrations.Migration):
                 ("name", models.CharField(blank=True, max_length=255, null=True)),
                 ("category", models.CharField(default="", max_length=255)),
                 ("version", models.BigIntegerField(blank=True, null=True)),
+                ("tenant_id", models.BigIntegerField(blank=True, null=True)),
             ],
             options={
                 "unique_together": {("name", "category"), ("uuid", "category")},

--- a/event_sourcery_django/models.py
+++ b/event_sourcery_django/models.py
@@ -8,9 +8,13 @@ from event_sourcery.event_store import StreamId
 
 
 class StreamManager(models.Manager):
-    def by_stream_id(self, stream_id: StreamId) -> models.QuerySet:
+    def by_stream_id(
+        self,
+        stream_id: StreamId,
+        tenant_id: int | None = None,  # TODO: tenant_id MUST NOT be optional
+    ) -> models.QuerySet:
         category = stream_id.category or ""
-        condition = models.Q(uuid=stream_id, category=category)
+        condition = models.Q(uuid=stream_id, category=category, tenant_id=tenant_id)
         if stream_id.name:
             condition = condition | models.Q(name=stream_id.name, category=category)
         return self.filter(condition)
@@ -24,6 +28,7 @@ class Stream(models.Model):
     name = models.CharField(max_length=255, null=True, blank=True)
     category = models.CharField(max_length=255, default="")
     version = models.BigIntegerField(null=True, blank=True)
+    tenant_id = models.BigIntegerField(null=True, blank=True)
 
     objects = StreamManager()
 

--- a/event_sourcery_esdb/event_store.py
+++ b/event_sourcery_esdb/event_store.py
@@ -11,6 +11,7 @@ from event_sourcery.event_store import (
     StreamId,
     Versioning,
 )
+from event_sourcery.event_store.context import Context
 from event_sourcery.event_store.exceptions import ConcurrentStreamWriteError
 from event_sourcery.event_store.interfaces import StorageStrategy
 from event_sourcery_esdb import dto, stream
@@ -23,6 +24,7 @@ class ESDBStorageStrategy(StorageStrategy):
     def fetch_events(
         self,
         stream_id: StreamId,
+        context: Context,
         start: int | None = None,
         stop: int | None = None,
     ) -> list[RawEvent]:
@@ -58,7 +60,11 @@ class ESDBStorageStrategy(StorageStrategy):
             return None
 
     def insert_events(
-        self, stream_id: StreamId, versioning: Versioning, events: list[RawEvent]
+        self,
+        stream_id: StreamId,
+        versioning: Versioning,
+        events: list[RawEvent],
+        context: Context,
     ) -> None:
         self._ensure_stream(stream_id=stream_id, versioning=versioning)
         for stream_id in {e.stream_id for e in events}:

--- a/event_sourcery_sqlalchemy/event_store.py
+++ b/event_sourcery_sqlalchemy/event_store.py
@@ -14,6 +14,7 @@ from event_sourcery.event_store import (
     StreamId,
     Versioning,
 )
+from event_sourcery.event_store.context import Context
 from event_sourcery.event_store.exceptions import (
     AnotherStreamWithThisNameButOtherIdExists,
     ConcurrentStreamWriteError,
@@ -33,6 +34,7 @@ class SqlAlchemyStorageStrategy(StorageStrategy):
     def fetch_events(
         self,
         stream_id: StreamId,
+        context: Context,
         start: int | None = None,
         stop: int | None = None,
     ) -> list[RawEvent]:
@@ -156,7 +158,11 @@ class SqlAlchemyStorageStrategy(StorageStrategy):
                 raise ConcurrentStreamWriteError
 
     def insert_events(
-        self, stream_id: StreamId, versioning: Versioning, events: list[RawEvent]
+        self,
+        stream_id: StreamId,
+        versioning: Versioning,
+        events: list[RawEvent],
+        context: Context,
     ) -> None:
         self._ensure_stream(stream_id=stream_id, versioning=versioning)
         stream = cast(

--- a/tests/event_store/multitenancy/test_stream_isolation.py
+++ b/tests/event_store/multitenancy/test_stream_isolation.py
@@ -1,0 +1,66 @@
+import pytest
+
+from event_sourcery.event_store import StreamId
+from event_sourcery.event_store.context import event_sourcery_context
+from tests.bdd import Given, Then
+from tests.factories import an_event
+
+pytestmark = pytest.mark.skip_backend(
+    backend=["esdb", "in_memory", "sqlalchemy_sqlite", "sqlalchemy_postgres"],
+    reason="Skipped for now, for the sake of PoC.",
+)
+
+
+def test_one_tenant_doesnt_see_streams_of_other_tenants(
+    given: Given,
+    then: Then,
+) -> None:
+    with event_sourcery_context(tenant_id=1):
+        events = [an_event() for _ in range(3)]
+        stream_1 = given.stream().with_events(*events)
+    with event_sourcery_context(tenant_id=2):
+        stream_2 = given.stream().with_events(*[an_event() for _ in range(3)])
+
+    with event_sourcery_context(tenant_id=1):
+        then.stream(stream_1.id).loads_only(events)
+        then.stream(stream_2.id).is_empty()
+
+
+def test_context_is_reentrant(
+    given: Given,
+    then: Then,
+) -> None:
+    with event_sourcery_context(tenant_id=1):
+        events = [an_event(), an_event()]
+        stream = given.stream().with_events(*events)
+
+    with event_sourcery_context(tenant_id=2):
+        then.stream(stream.id).is_empty()
+
+        with event_sourcery_context(tenant_id=1):
+            then.stream(stream.id).loads_only(events)
+
+            with event_sourcery_context(tenant_id=2):
+                then.stream(stream.id).is_empty()
+
+
+@pytest.mark.xfail(reason="Unsure how this should behave")
+def test_streams_with_same_id_under_different_tenants(
+    given: Given,
+    then: Then,
+) -> None:
+    stream_id = StreamId()
+    with event_sourcery_context(tenant_id=1):
+        event_of_first_tenant = an_event()
+        given.stream(stream_id).with_events(event_of_first_tenant)
+
+    with event_sourcery_context(tenant_id=2):
+        event_of_second_tenant = an_event()
+        # TODO: should this raise an exception? Should this pass?
+        given.stream(stream_id).with_events(event_of_second_tenant)
+
+    with event_sourcery_context(tenant_id=1):
+        then.stream(stream_id).loads_only([event_of_first_tenant])
+
+    with event_sourcery_context(tenant_id=2):
+        then.stream(stream_id).loads_only([event_of_second_tenant])


### PR DESCRIPTION
Play around with API.

The first attempt assumes using `ContextVars` and context managers:

```python
from event_sourcery.event_store.context import event_sourcery_context

with event_sourcery_context(tenant_id=1):
    # do sth as tenant_1, e.g. create streams etc
```

There are lots of open questions, e.g.
- how far the isolation should go, 
- is it possible to achieve certain things stuff in EventStoreDB etc
- should we allow the same stream IDs inside the tenant context as well as outside of it (and should tenants be able to reuse the same stream_id),
- the same goes for stream names
- should we rather have a separate `EventStore` subclass that allows to work with multitenancy and by default have this disabled (so it looks like there is no multitenancy)

Here's some Example Mapping I tried to make to visualize how I think about it:

![obraz](https://github.com/python-event-sourcery/python-event-sourcery/assets/647761/2d70675e-0f84-47d2-bc22-f83bfa16c68a)
