### PR TITLE
Stricter typing for built in types, except Event

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SRC_DIRS ?= ${wildcard event_sourcery*}
 lint:
 	ruff format $(SRC_DIRS) tests/
 	ruff check $(SRC_DIRS) tests/ --fix
-	mypy $(SRC_DIRS) tests/
+	mypy --enable-incomplete-feature=NewGenericSyntax $(SRC_DIRS) tests/
 
 .PHONY: test
 test:

--- a/event_sourcery/event_store/__init__.py
+++ b/event_sourcery/event_store/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     "Dispatcher",
     "Entry",
     "Event",
+    "Context",
     "EventRegistry",
     "EventStore",
     "ExplicitVersioning",
@@ -29,6 +30,7 @@ __all__ = [
 from event_sourcery.event_store import exceptions, factory, interfaces, subscription
 from event_sourcery.event_store.dispatcher import Dispatcher, Listener
 from event_sourcery.event_store.event import (
+    Context,
     Entry,
     Event,
     EventRegistry,

--- a/event_sourcery/event_store/event/dto.py
+++ b/event_sourcery/event_store/event/dto.py
@@ -10,19 +10,21 @@ from event_sourcery.event_store.stream_id import StreamId
 from event_sourcery.event_store.tenant_id import DEFAULT_TENANT, TenantId
 
 
+@dataclasses.dataclass(frozen=True)
 class RawEvent(BaseModel):
     uuid: UUID
     stream_id: StreamId
     created_at: datetime
-    version: int | None = None
     name: str
     data: dict
     context: dict
+    version: int | None = None
 
 
 Position: TypeAlias = int
 
 
+@dataclasses.dataclass(frozen=True)
 class RecordedRaw(BaseModel):
     entry: RawEvent
     position: Position

--- a/event_sourcery/event_store/event/dto.py
+++ b/event_sourcery/event_store/event/dto.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+import dataclasses
+from datetime import datetime, timezone
 from typing import Any, ClassVar, Generic, TypeAlias, TypeVar
 from uuid import UUID, uuid4
 
@@ -70,7 +71,9 @@ class WrappedEvent(BaseModel, Generic[TEvent], extra="forbid"):
     event: TEvent
     version: int | None
     uuid: UUID = Field(default_factory=uuid4)
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None)
+    )
     context: Context = Field(default_factory=Context)
 
     @classmethod
@@ -78,11 +81,13 @@ class WrappedEvent(BaseModel, Generic[TEvent], extra="forbid"):
         return WrappedEvent[TEvent](event=event, version=version)
 
 
-class Entry(BaseModel):
+@dataclasses.dataclass(frozen=True)
+class Entry:
     wrapped_event: WrappedEvent
     stream_id: StreamId
 
 
+@dataclasses.dataclass(frozen=True)
 class Recorded(Entry):
     position: Position
     tenant_id: TenantId = DEFAULT_TENANT

--- a/event_sourcery/event_store/event/dto.py
+++ b/event_sourcery/event_store/event/dto.py
@@ -1,6 +1,6 @@
 import dataclasses
 from datetime import datetime, timezone
-from typing import Any, ClassVar, TypeAlias, TypeVar
+from typing import Any, ClassVar, Generic, TypeAlias, TypeVar
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel
@@ -56,7 +56,7 @@ class Context(BaseModel, extra="allow"):
 
 
 @dataclasses.dataclass()
-class WrappedEvent[TEvent]:
+class WrappedEvent(Generic[TEvent]):
     """Wrapper for events with all relevant metadata.
 
     Returned from EventStore when loading events from a stream.

--- a/event_sourcery/event_store/event/dto.py
+++ b/event_sourcery/event_store/event/dto.py
@@ -1,9 +1,9 @@
 import dataclasses
 from datetime import datetime, timezone
-from typing import Any, ClassVar, Generic, TypeAlias, TypeVar
+from typing import Any, ClassVar, TypeAlias, TypeVar
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from event_sourcery.event_store.event.registry import EventRegistry
 from event_sourcery.event_store.stream_id import StreamId
@@ -53,7 +53,8 @@ class Context(BaseModel, extra="allow"):
     causation_id: UUID | None = None
 
 
-class WrappedEvent(BaseModel, Generic[TEvent], extra="forbid"):
+@dataclasses.dataclass()
+class WrappedEvent[TEvent]:
     """Wrapper for events with all relevant metadata.
 
     Returned from EventStore when loading events from a stream.
@@ -70,11 +71,11 @@ class WrappedEvent(BaseModel, Generic[TEvent], extra="forbid"):
 
     event: TEvent
     version: int | None
-    uuid: UUID = Field(default_factory=uuid4)
-    created_at: datetime = Field(
+    uuid: UUID = dataclasses.field(default_factory=uuid4)
+    created_at: datetime = dataclasses.field(
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None)
     )
-    context: Context = Field(default_factory=Context)
+    context: Context = dataclasses.field(default_factory=Context)
 
     @classmethod
     def wrap(cls, event: TEvent, version: int | None) -> "WrappedEvent[TEvent]":

--- a/event_sourcery/event_store/event/serde.py
+++ b/event_sourcery/event_store/event/serde.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import cast
 
 from event_sourcery.event_store.event.dto import (
+    Context,
     Event,
     RawEvent,
     Recorded,
@@ -22,8 +23,10 @@ class Serde:
         del event_as_dict["stream_id"]
         del event_as_dict["name"]
         data = cast(Mapping, event_as_dict.pop("data"))
+        context = event_as_dict.pop("context", {})
+        event_as_dict["context"] = Context(**context)
         event_type = self.registry.type_for_name(event.name)
-        return WrappedEvent[event_type](  # type: ignore
+        return WrappedEvent[event_type](  # type: ignore[valid-type]
             **event_as_dict,
             event=event_type(**data),
         )

--- a/event_sourcery/event_store/event/serde.py
+++ b/event_sourcery/event_store/event/serde.py
@@ -1,3 +1,4 @@
+import dataclasses
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import cast
@@ -19,7 +20,7 @@ class Serde:
     registry: EventRegistry
 
     def deserialize(self, event: RawEvent) -> WrappedEvent:
-        event_as_dict = dict(event)
+        event_as_dict = dataclasses.asdict(event)
         del event_as_dict["stream_id"]
         del event_as_dict["name"]
         data = cast(Mapping, event_as_dict.pop("data"))

--- a/event_sourcery_django/dto.py
+++ b/event_sourcery_django/dto.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 from event_sourcery.event_store import RawEvent, RecordedRaw, StreamId
@@ -47,7 +47,7 @@ def snapshot(from_raw: RawEvent, to_stream: Stream) -> Snapshot:
 
 def outbox_entry(from_raw: RecordedRaw, max_attempts: int) -> OutboxEntry:
     return OutboxEntry(
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc).replace(tzinfo=None),
         data={
             "created_at": from_raw.entry.created_at.isoformat(),
             "uuid": str(from_raw.entry.uuid),

--- a/event_sourcery_sqlalchemy/outbox.py
+++ b/event_sourcery_sqlalchemy/outbox.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Generator, Iterator
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import cast
 from uuid import UUID
 
@@ -39,7 +39,7 @@ class SqlAlchemyOutboxStorageStrategy(OutboxStorageStrategy):
             as_dict["tenant_id"] = str(record.tenant_id)
             rows.append(
                 {
-                    "created_at": datetime.utcnow(),
+                    "created_at": datetime.now(timezone.utc).replace(tzinfo=None),
                     "data": as_dict,
                     "stream_name": record.entry.stream_id.name,
                     "position": record.position,

--- a/event_sourcery_sqlalchemy/outbox.py
+++ b/event_sourcery_sqlalchemy/outbox.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 from collections.abc import Generator, Iterator
 from contextlib import AbstractContextManager, contextmanager
@@ -31,11 +32,13 @@ class SqlAlchemyOutboxStorageStrategy(OutboxStorageStrategy):
             if not self._filterer(record.entry):
                 continue
 
-            as_dict = dict(record.entry)
+            stream_id = record.entry.stream_id
+            as_dict = dataclasses.asdict(record.entry)
+            as_dict.pop("stream_id")
             created_at = cast(datetime, as_dict["created_at"])
             as_dict["created_at"] = created_at.isoformat()
             as_dict["uuid"] = str(as_dict["uuid"])
-            as_dict["stream_id"] = str(as_dict["stream_id"])
+            as_dict["stream_id"] = str(stream_id)
             as_dict["tenant_id"] = str(record.tenant_id)
             rows.append(
                 {

--- a/tests/event_store/event/test_custom_event_registry.py
+++ b/tests/event_store/event/test_custom_event_registry.py
@@ -33,7 +33,7 @@ def test_can_work_with_custom_events_with_custom_registry(
 
     stream_id = StreamId(uuid4())
     event_store.append(
-        WrappedEvent[SomeDummyEvent](event=SomeDummyEvent(), version=1),
+        WrappedEvent[SomeDummyEvent](event=SomeDummyEvent(), version=1),  # type: ignore
         stream_id=stream_id,
     )
 

--- a/tests/event_store/event/test_custom_event_registry.py
+++ b/tests/event_store/event/test_custom_event_registry.py
@@ -33,7 +33,7 @@ def test_can_work_with_custom_events_with_custom_registry(
 
     stream_id = StreamId(uuid4())
     event_store.append(
-        WrappedEvent[SomeDummyEvent](event=SomeDummyEvent(), version=1),  # type: ignore
+        WrappedEvent[SomeDummyEvent](event=SomeDummyEvent(), version=1),
         stream_id=stream_id,
     )
 

--- a/tests/event_store/event/test_dto.py
+++ b/tests/event_store/event/test_dto.py
@@ -1,11 +1,11 @@
 import pytest
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 
-from event_sourcery.event_store.event.dto import Event, WrappedEvent
+from event_sourcery.event_store.event.dto import Context, Event, WrappedEvent
 
 
 def test_wrapped_event_doesnt_accept_extra_fields() -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(TypeError):
         WrappedEvent(this_field_is_not_defined=True)  # type: ignore
 
 
@@ -18,10 +18,12 @@ def test_extra_data_can_be_passed_to_wrapped_event_context() -> None:
     an_event: WrappedEvent[Event] = WrappedEvent(
         event=Event(),
         version=1,
-        context={"extra": {"age": 2**5}},  # type: ignore
+        context=Context(extra={"age": 2**5}),  # type: ignore[call-arg]
     )
 
-    assert an_event.context.model_dump() == {
+    type_adapter = TypeAdapter[WrappedEvent[Event]](WrappedEvent[Event])
+
+    assert type_adapter.dump_python(an_event)["context"] == {
         "correlation_id": None,
         "causation_id": None,
         "extra": {"age": 2**5},

--- a/tests/event_store/test_category.py
+++ b/tests/event_store/test_category.py
@@ -2,13 +2,10 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from event_sourcery.event_store import Event, StreamId
+from event_sourcery.event_store import StreamId
 from tests.bdd import Given, Then, When
+from tests.factories import AnEvent
 from tests.matchers import any_wrapped_event
-
-
-class AnEvent(Event):
-    pass
 
 
 @pytest.mark.parametrize(

--- a/tests/event_store/test_named_streams.py
+++ b/tests/event_store/test_named_streams.py
@@ -3,16 +3,13 @@ from uuid import uuid4
 import pytest
 from _pytest.fixtures import SubRequest
 
-from event_sourcery.event_store import BackendFactory, Event, StreamId
+from event_sourcery.event_store import BackendFactory, StreamId
 from event_sourcery.event_store.exceptions import (
     AnotherStreamWithThisNameButOtherIdExists,
     IllegalCategoryName,
 )
 from tests.bdd import Given, Then, When
-
-
-class AnEvent(Event):
-    pass
+from tests.factories import AnEvent
 
 
 def test_can_append_then_load_with_named_stream(given: Given, then: Then) -> None:

--- a/tests/event_store/test_no_versioning.py
+++ b/tests/event_store/test_no_versioning.py
@@ -1,15 +1,12 @@
 import pytest
 
-from event_sourcery.event_store import NO_VERSIONING, Event, StreamId
+from event_sourcery.event_store import NO_VERSIONING, StreamId
 from event_sourcery.event_store.exceptions import (
     ExpectedVersionUsedOnVersionlessStream,
     NoExpectedVersionGivenOnVersionedStream,
 )
 from tests.bdd import Given, Then, When
-
-
-class AnEvent(Event):
-    pass
+from tests.factories import AnEvent
 
 
 def test_versionless_stream_is_supported(given: Given, when: When, then: Then) -> None:

--- a/tests/matchers.py
+++ b/tests/matchers.py
@@ -29,7 +29,7 @@ def any_record(
 ) -> Recorded:
     if isinstance(event, Event):
         event = any_wrapped_event(event)
-    return Recorded.model_construct(
+    return Recorded(
         wrapped_event=event,
         stream_id=on_stream,
         tenant_id=for_tenant,

--- a/tests/matchers.py
+++ b/tests/matchers.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Any, TypeVar
 from unittest.mock import ANY
 from uuid import UUID
@@ -13,7 +14,7 @@ class AnyUUID:
 
 
 def any_wrapped_event(for_event: TEvent) -> WrappedEvent[TEvent]:
-    return WrappedEvent[TEvent].model_construct(
+    return WrappedEvent[TEvent](
         event=for_event,
         version=ANY,
         uuid=ANY,
@@ -29,6 +30,9 @@ def any_record(
 ) -> Recorded:
     if isinstance(event, Event):
         event = any_wrapped_event(event)
+    elif event.version is None:
+        event = dataclasses.replace(event, version=ANY)
+
     return Recorded(
         wrapped_event=event,
         stream_id=on_stream,


### PR DESCRIPTION
We need (because we want :D) support for static type checking during the creation of many built-in types.

The same should be true for `Event` but I couldn't use a simple solution with dataclasses like I did for remaining cases.

I need another approach, perhaps just creating an abstract Protocol to detect whether an Event instance is a dataclass:
https://github.com/hauntsaninja/useful_types/blob/main/useful_types/experimental.py#L29